### PR TITLE
Some minor fixes to deal with missing tkinter and easy_install errors

### DIFF
--- a/deepneuro/__init__.py
+++ b/deepneuro/__init__.py
@@ -1,3 +1,6 @@
+import matplotlib as mpl
+mpl.use('Agg')
+
 import warnings
 
 warnings.filterwarnings("ignore", message=".*dtype size changed.*")

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ import sys
 from setuptools import setup, find_packages
 from codecs import open
 from os import path
+import os
+
+os.environ["MPLCONFIGDIR"] = "."
 
 if sys.version_info[:2] < (2, 7):
     raise RuntimeError("Python version 2.7 or greater required.")


### PR DESCRIPTION
In trying to get DeepNeuro set up in a deepo container (https://github.com/ufoym/deepo), it would failed in several distinct ways:

* matplotlib requiring tkinter by default
* easy_install - failing install in `/root/.config`
* lycon - some dependencies missing (not fixed, but solved with system package updates below)

I addressed the lycon issues separately by first running:
`sudo apt-get install cmake build-essential libjpeg-dev libpng-dev`
